### PR TITLE
Publish action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         uses: "coursier/cache-action@b74a57cd5434385877191a348c5f9929f064fda5"
 
       - name: "Install Nix"
-        uses: "nixbuild/nix-quick-install-action@1481852014c158076f88e3edced1e4609c7d954b"
+        uses: "nixbuild/nix-quick-install-action@b0cf1019a4b54e3b5d2c77c05b394292f25312de"
 
       - name: "sbt validate"
         run: nix-shell shell.nix --run "sbt --batch +validate"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
         uses: "coursier/cache-action@b74a57cd5434385877191a348c5f9929f064fda5"
 
       - name: "Install Nix"
-        uses: "nixbuild/nix-quick-install-action@1481852014c158076f88e3edced1e4609c7d954b"
+        uses: "nixbuild/nix-quick-install-action@b0cf1019a4b54e3b5d2c77c05b394292f25312de"
 
       - name: "sbt validate"
         run: nix-shell shell.nix --run "sbt --batch +validate"


### PR DESCRIPTION
This is mostly copied from the existing `ci.yml` action in the same
directory. Unfortunately I don't know of a good way to deduplicate logic
via GitHub Action Yaml files.

I had to update the nix-quick-install-action since the old version was using deprecated GitHub Actions commands.

Eventually hopefully this will also publish to Sonatype.