### PR TITLE
Change README to point to docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # maligned - a Scala library for type-aligned sequences
 
-More information coming soon!
+For documentation, visit the [maligned website](https://salesforce.github.io/maligned/)!


### PR DESCRIPTION
The site isn't currently public, but the link should work if you have
access to the repo.