### PR TITLE
Fix doc source links

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,9 @@ lazy val docs = project
       "scaladoc.maligned.base_url" -> ".../api/com/salesforce",
       "organization" -> organization.value,
       "version" -> version.value,
-      "sourceUrl" -> githubRepoUrl
+      "sourceUrl" -> githubRepoUrl,
+      // Paradox defaults to the 'master' branch but we use 'main'
+      "github.base_url" -> s"$githubRepoUrl/tree/main"
     )
   )
   .dependsOn(core)


### PR DESCRIPTION
At the bottom of each doc page there is a `The source code for this page
can be found here.` link. Currently those use the Paradox default of the
`master` branch, but maligned uses the `main` branch. This change
prevents GitHub from giving a warning about the branch not being found.